### PR TITLE
docs: improve client_pin documentation and update example

### DIFF
--- a/soft-fido2/examples/authenticator.rs
+++ b/soft-fido2/examples/authenticator.rs
@@ -146,7 +146,8 @@ fn main() -> Result<()> {
         0x88,
     ];
     let options = AuthenticatorOptions::new()
-        .with_user_verification(Some(true))
+        .with_user_verification(Some(false))
+        .with_client_pin(Some(true))
         .with_credential_management(Some(true));
     let extensions = vec!["credProtect".to_string(), "federationId".to_string()];
     let max_creds = 100;

--- a/soft-fido2/src/options.rs
+++ b/soft-fido2/src/options.rs
@@ -23,7 +23,9 @@ pub struct AuthenticatorOptions {
     /// Platform device (cannot be removed)
     pub plat: bool,
 
-    /// Client PIN capability
+    /// Client PIN capability. When `Some(true)` and UV is available, the
+    /// browser/client may defer verification to the authenticator instead of
+    /// prompting the user locally.
     pub client_pin: Option<bool>,
 
     /// PIN/UV auth token support


### PR DESCRIPTION
- Add detailed documentation for client_pin option explaining its role in deferring verification to the authenticator when UV is available
- Update example authenticator to use client_pin=Some(true) with uv=Some(false) to demonstrate PIN-based authentication flow

This configuration better demonstrates the typical use case where client PIN is used for authentication instead of platform UV.