### PR TITLE
fix: Clean callbacks interface

### DIFF
--- a/soft-fido2/examples/authenticator.rs
+++ b/soft-fido2/examples/authenticator.rs
@@ -71,13 +71,13 @@ impl AuthenticatorCallbacks for SimpleCallbacks {
         Ok(UvResult::Accepted)
     }
 
-    fn write_credential(&self, cred_id: &[u8], _rp_id: &str, cred: &CredentialRef) -> Result<()> {
+    fn write_credential(&self, cred: &CredentialRef) -> Result<()> {
         let mut store = self.credentials.lock().unwrap();
-        store.insert(cred_id.to_vec(), cred.to_owned());
+        store.insert(cred.id.to_vec(), cred.to_owned());
         Ok(())
     }
 
-    fn read_credential(&self, cred_id: &[u8], _rp_id: &str) -> Result<Option<Credential>> {
+    fn read_credential(&self, cred_id: &[u8]) -> Result<Option<Credential>> {
         let store = self.credentials.lock().unwrap();
         let result = store.get(cred_id).cloned();
         Ok(result)

--- a/soft-fido2/examples/virtual_authenticator.rs
+++ b/soft-fido2/examples/virtual_authenticator.rs
@@ -220,12 +220,12 @@ impl AuthenticatorCallbacks for VirtualAuthCallbacks {
         Ok(UvResult::Accepted)
     }
 
-    fn write_credential(&self, cred_id: &[u8], rp_id: &str, cred: &CredentialRef) -> Result<()> {
+    fn write_credential(&self, cred: &CredentialRef) -> Result<()> {
         let mut store = self.credentials.lock().unwrap();
-        store.insert(cred_id.to_vec(), cred.to_owned());
+        store.insert(cred.id.to_vec(), cred.to_owned());
 
         println!("\n✓ CREDENTIAL REGISTERED");
-        println!("  RP ID: {}", rp_id);
+        println!("  RP ID: {}", cred.rp_id);
         if let Some(user_name) = cred.user_name {
             println!("  User: {}", user_name);
         }
@@ -243,7 +243,7 @@ impl AuthenticatorCallbacks for VirtualAuthCallbacks {
         Ok(())
     }
 
-    fn read_credential(&self, cred_id: &[u8], _rp_id: &str) -> Result<Option<Credential>> {
+    fn read_credential(&self, cred_id: &[u8]) -> Result<Option<Credential>> {
         let store = self.credentials.lock().unwrap();
         match store.get(cred_id) {
             Some(cred) => {

--- a/soft-fido2/tests/common/mod.rs
+++ b/soft-fido2/tests/common/mod.rs
@@ -53,13 +53,13 @@ impl AuthenticatorCallbacks for TestCallbacks {
         Ok(UvResult::Accepted)
     }
 
-    fn write_credential(&self, cred_id: &[u8], _rp_id: &str, cred: &CredentialRef) -> Result<()> {
+    fn write_credential(&self, cred: &CredentialRef) -> Result<()> {
         let mut store = self.credentials.lock().unwrap();
-        store.insert(cred_id.to_vec(), cred.to_owned());
+        store.insert(cred.id.to_vec(), cred.to_owned());
         Ok(())
     }
 
-    fn read_credential(&self, cred_id: &[u8], _rp_id: &str) -> Result<Option<Credential>> {
+    fn read_credential(&self, cred_id: &[u8]) -> Result<Option<Credential>> {
         let store = self.credentials.lock().unwrap();
         Ok(store.get(cred_id).cloned())
     }
@@ -142,22 +142,20 @@ impl AuthenticatorCallbacks for VerboseTestCallbacks {
         self.inner.request_uv(info, user, rp)
     }
 
-    fn write_credential(&self, cred_id: &[u8], rp_id: &str, cred: &CredentialRef) -> Result<()> {
+    fn write_credential(&self, cred: &CredentialRef) -> Result<()> {
         eprintln!(
-            "[Callback] write_credential: cred_id={}, rp_id='{}', user_name={:?}",
-            hex::encode(cred_id),
-            rp_id,
+            "[Callback] write_credential: cred_id={}, user_name={:?}",
+            hex::encode(cred.id),
             cred.user_name
         );
-        self.inner.write_credential(cred_id, rp_id, cred)
+        self.inner.write_credential(cred)
     }
 
-    fn read_credential(&self, cred_id: &[u8], rp_id: &str) -> Result<Option<Credential>> {
-        let result = self.inner.read_credential(cred_id, rp_id)?;
+    fn read_credential(&self, cred_id: &[u8]) -> Result<Option<Credential>> {
+        let result = self.inner.read_credential(cred_id)?;
         eprintln!(
-            "[Callback] read_credential: cred_id={}, rp_id='{}', found={}",
+            "[Callback] read_credential: cred_id={}, found={}",
             hex::encode(cred_id),
-            rp_id,
             result.is_some()
         );
         Ok(result)

--- a/soft-fido2/tests/credential_management_e2e_test.rs
+++ b/soft-fido2/tests/credential_management_e2e_test.rs
@@ -172,22 +172,13 @@ impl AuthenticatorCallbacks for TestCallbacks {
         Ok(UvResult::Accepted)
     }
 
-    fn write_credential(
-        &self,
-        cred_id: &[u8],
-        _rp_id: &str,
-        cred: &CredentialRef,
-    ) -> soft_fido2::Result<()> {
+    fn write_credential(&self, cred: &CredentialRef) -> soft_fido2::Result<()> {
         let mut store = self.credentials.lock().unwrap();
-        store.insert(cred_id.to_vec(), cred.to_owned());
+        store.insert(cred.id.to_vec(), cred.to_owned());
         Ok(())
     }
 
-    fn read_credential(
-        &self,
-        cred_id: &[u8],
-        _rp_id: &str,
-    ) -> soft_fido2::Result<Option<Credential>> {
+    fn read_credential(&self, cred_id: &[u8]) -> soft_fido2::Result<Option<Credential>> {
         let store = self.credentials.lock().unwrap();
         Ok(store.get(cred_id).cloned())
     }

--- a/soft-fido2/tests/e2e_webauthn_comprehensive_test.rs
+++ b/soft-fido2/tests/e2e_webauthn_comprehensive_test.rs
@@ -85,14 +85,9 @@ impl AuthenticatorCallbacks for UvTestCallbacks {
         Ok(UvResult::Accepted)
     }
 
-    fn write_credential(
-        &self,
-        cred_id: &[u8],
-        _rp_id: &str,
-        cred: &CredentialRef,
-    ) -> SoftFido2Result<()> {
+    fn write_credential(&self, cred: &CredentialRef) -> SoftFido2Result<()> {
         let mut store = self.credentials.lock().unwrap();
-        store.insert(cred_id.to_vec(), cred.to_owned());
+        store.insert(cred.id.to_vec(), cred.to_owned());
 
         // Track user -> credential mapping
         if let Some(user_name) = cred.user_name
@@ -102,14 +97,14 @@ impl AuthenticatorCallbacks for UvTestCallbacks {
             mappings
                 .entry(user_name.to_string())
                 .or_default()
-                .push(cred_id.to_vec());
+                .push(cred.id.to_vec());
         }
 
         eprintln!("    [Auth] Stored credential (total: {})", store.len());
         Ok(())
     }
 
-    fn read_credential(&self, cred_id: &[u8], _rp_id: &str) -> SoftFido2Result<Option<Credential>> {
+    fn read_credential(&self, cred_id: &[u8]) -> SoftFido2Result<Option<Credential>> {
         let store = self.credentials.lock().unwrap();
         Ok(store.get(cred_id).cloned())
     }
@@ -213,18 +208,13 @@ impl AuthenticatorCallbacks for UpOnlyTestCallbacks {
         Ok(UvResult::Denied)
     }
 
-    fn write_credential(
-        &self,
-        cred_id: &[u8],
-        _rp_id: &str,
-        cred: &CredentialRef,
-    ) -> SoftFido2Result<()> {
+    fn write_credential(&self, cred: &CredentialRef) -> SoftFido2Result<()> {
         let mut store = self.credentials.lock().unwrap();
-        store.insert(cred_id.to_vec(), cred.to_owned());
+        store.insert(cred.id.to_vec(), cred.to_owned());
         Ok(())
     }
 
-    fn read_credential(&self, cred_id: &[u8], _rp_id: &str) -> SoftFido2Result<Option<Credential>> {
+    fn read_credential(&self, cred_id: &[u8]) -> SoftFido2Result<Option<Credential>> {
         let store = self.credentials.lock().unwrap();
         Ok(store.get(cred_id).cloned())
     }

--- a/soft-fido2/tests/webauthn_compliance_test.rs
+++ b/soft-fido2/tests/webauthn_compliance_test.rs
@@ -44,13 +44,13 @@ impl AuthenticatorCallbacks for TestCallbacks {
         Ok(UvResult::Accepted)
     }
 
-    fn write_credential(&self, cred_id: &[u8], _rp_id: &str, cred: &CredentialRef) -> Result<()> {
+    fn write_credential(&self, cred: &CredentialRef) -> Result<()> {
         let mut store = self.credentials.lock().unwrap();
-        store.insert(cred_id.to_vec(), cred.to_owned());
+        store.insert(cred.id.to_vec(), cred.to_owned());
         Ok(())
     }
 
-    fn read_credential(&self, cred_id: &[u8], _rp_id: &str) -> Result<Option<Credential>> {
+    fn read_credential(&self, cred_id: &[u8]) -> Result<Option<Credential>> {
         let store = self.credentials.lock().unwrap();
         Ok(store.get(cred_id).cloned())
     }


### PR DESCRIPTION
BREAKING CHANGE: `write_credential` and `read_credential` fingerprints have being updated.