### PR TITLE
fix: Support getNextAssertion for resident credentials

### DIFF
--- a/soft-fido2-ctap/src/authenticator.rs
+++ b/soft-fido2-ctap/src/authenticator.rs
@@ -330,6 +330,23 @@ impl AuthenticatorOptions {
     }
 }
 
+const ASSERTION_STATE_TIMEOUT_MS: u64 = 30_000;
+
+/// Context shared by authenticatorGetAssertion and authenticatorGetNextAssertion.
+#[derive(Clone)]
+pub struct AssertionContext {
+    pub client_data_hash: Vec<u8>,
+    pub rp_id: String,
+    pub up: bool,
+    pub uv: bool,
+}
+
+struct AssertionState {
+    remaining_credentials: Vec<crate::types::Credential>,
+    context: AssertionContext,
+    created_at: u64,
+}
+
 /// Authenticator state machine
 ///
 /// Central component managing authenticator configuration, PIN state,
@@ -376,6 +393,9 @@ pub struct Authenticator<C: AuthenticatorCallbacks> {
 
     /// Current index in credential enumeration
     credential_enumeration_index: usize,
+
+    /// Assertion state for getNextAssertion
+    assertion_state: Option<AssertionState>,
 }
 
 impl<C: AuthenticatorCallbacks> Authenticator<C> {
@@ -408,6 +428,7 @@ impl<C: AuthenticatorCallbacks> Authenticator<C> {
             rp_enumeration_index: 0,
             credential_enumeration_state: None,
             credential_enumeration_index: 0,
+            assertion_state: None,
         }
     }
 
@@ -884,6 +905,68 @@ impl<C: AuthenticatorCallbacks> Authenticator<C> {
         Ok(cred)
     }
 
+    /// Store remaining assertion credentials for getNextAssertion.
+    pub fn start_assertion(
+        &mut self,
+        remaining_credentials: Vec<crate::types::Credential>,
+        client_data_hash: Vec<u8>,
+        rp_id: String,
+        up: bool,
+        uv: bool,
+    ) {
+        if remaining_credentials.is_empty() {
+            self.assertion_state = None;
+            return;
+        }
+
+        self.assertion_state = Some(AssertionState {
+            remaining_credentials,
+            context: AssertionContext {
+                client_data_hash,
+                rp_id,
+                up,
+                uv,
+            },
+            created_at: self.callbacks.get_timestamp_ms(),
+        });
+    }
+
+    /// Return the next assertion credential and its original assertion context.
+    pub fn get_next_assertion(
+        &mut self,
+    ) -> Result<(crate::types::Credential, AssertionContext, usize), StatusCode> {
+        let now = self.callbacks.get_timestamp_ms();
+        let state = self
+            .assertion_state
+            .as_mut()
+            .ok_or(StatusCode::NoCredentials)?;
+
+        if now.saturating_sub(state.created_at) > ASSERTION_STATE_TIMEOUT_MS {
+            self.assertion_state = None;
+            return Err(StatusCode::UserActionTimeout);
+        }
+
+        if state.remaining_credentials.is_empty() {
+            self.assertion_state = None;
+            return Err(StatusCode::NoCredentials);
+        }
+
+        let credential = state.remaining_credentials.remove(0);
+        let context = state.context.clone();
+        let remaining = state.remaining_credentials.len();
+
+        if remaining == 0 {
+            self.assertion_state = None;
+        }
+
+        Ok((credential, context, remaining))
+    }
+
+    /// Clear pending getNextAssertion state.
+    pub fn clear_assertion_state(&mut self) {
+        self.assertion_state = None;
+    }
+
     /// Register a custom command handler
     ///
     /// # Arguments
@@ -982,6 +1065,7 @@ impl<C: AuthenticatorCallbacks> Authenticator<C> {
         self.pin_state = PinState::new();
         self.pin_tokens.clear_token();
         self.pin_protocol_keypairs.clear();
+        self.assertion_state = None;
 
         // Persist reset state if storage is configured
         self.save_pin_state()?;

--- a/soft-fido2-ctap/src/commands/get_assertion.rs
+++ b/soft-fido2-ctap/src/commands/get_assertion.rs
@@ -87,6 +87,7 @@ pub fn handle<C: AuthenticatorCallbacks>(
     data: &[u8],
 ) -> Result<Vec<u8>> {
     let parser = MapParser::from_bytes(data)?;
+    auth.clear_assertion_state();
 
     // ===== Parse all parameters first =====
 
@@ -702,10 +703,13 @@ pub fn handle<C: AuthenticatorCallbacks>(
     // Add numberOfCredentials if multiple credentials and no allowList
     if allow_list.is_none() && number_of_credentials > 1 {
         builder = builder.insert(resp_keys::NUMBER_OF_CREDENTIALS, number_of_credentials)?;
-        // Note: For authenticatorGetNextAssertion support, we would need to:
-        // - Store the remaining credentials
-        // - Start a timer
-        // - Track credential counter
+        auth.start_assertion(
+            credentials,
+            client_data_hash.clone(),
+            rp_id.clone(),
+            response_state.up,
+            response_state.uv,
+        );
     }
 
     // Add userSelected if credential was selected by user via authenticator interaction

--- a/soft-fido2-ctap/src/commands/get_next_assertion.rs
+++ b/soft-fido2-ctap/src/commands/get_next_assertion.rs
@@ -6,30 +6,130 @@
 //! Spec: <https://fidoalliance.org/specs/fido-v2.2-rd-20230321/fido-client-to-authenticator-protocol-v2.2-rd-20230321.html#authenticatorGetNextAssertion>
 
 use crate::{
-    authenticator::Authenticator,
+    authenticator::{AssertionContext, Authenticator},
     callbacks::AuthenticatorCallbacks,
+    cbor::MapBuilder,
     status::{Result, StatusCode},
+    types::{PublicKeyCredentialDescriptor, auth_data_flags},
 };
 
-use alloc::vec::Vec;
+use soft_fido2_crypto::{ecdsa, eddsa};
+
+use alloc::{string::ToString, vec::Vec};
+
+use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
+
+mod resp_keys {
+    pub const CREDENTIAL: i32 = 0x01;
+    pub const AUTH_DATA: i32 = 0x02;
+    pub const SIGNATURE: i32 = 0x03;
+    pub const USER: i32 = 0x04;
+    pub const NUMBER_OF_CREDENTIALS: i32 = 0x05;
+}
 
 /// Handle authenticatorGetNextAssertion command
 ///
 /// Returns the next assertion from the batch created by authenticatorGetAssertion.
-/// This is a simplified implementation that returns an error - full implementation
-/// would require maintaining assertion state in the Authenticator.
 pub fn handle<C: AuthenticatorCallbacks>(
-    _auth: &mut Authenticator<C>,
+    auth: &mut Authenticator<C>,
     _data: &[u8],
 ) -> Result<Vec<u8>> {
-    // TODO: Implement full getNextAssertion with state management
-    // For now, return NoCredentials to indicate no more assertions available
-    // A full implementation would:
-    // 1. Check if there's an ongoing assertion operation
-    // 2. Verify the assertion hasn't timed out
-    // 3. Return the next credential from the list
-    // 4. Update the remaining count
-    Err(StatusCode::NoCredentials)
+    let (credential, context, remaining) = auth.get_next_assertion()?;
+    build_assertion_response(auth, credential, context, remaining)
+}
+
+fn build_assertion_response<C: AuthenticatorCallbacks>(
+    auth: &mut Authenticator<C>,
+    credential: crate::types::Credential,
+    context: AssertionContext,
+    remaining: usize,
+) -> Result<Vec<u8>> {
+    let new_sign_count = if auth.config().constant_sign_count {
+        credential.sign_count
+    } else {
+        credential.sign_count + 1
+    };
+
+    if !auth.config().constant_sign_count && credential.discoverable {
+        let mut updated_cred = credential.clone();
+        updated_cred.sign_count = new_sign_count;
+        auth.callbacks().update_credential(&updated_cred)?;
+    }
+
+    let auth_data =
+        build_authenticator_data(&context.rp_id, context.up, context.uv, new_sign_count);
+    let sig_data = [&auth_data[..], &context.client_data_hash[..]].concat();
+
+    let key_bytes = credential.private_key.as_slice();
+    if key_bytes.len() != 32 {
+        return Err(StatusCode::InvalidCredential);
+    }
+
+    let priv_key_array = Zeroizing::new({
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(key_bytes);
+        arr
+    });
+
+    let signature = match credential.algorithm {
+        -8 | -19 => eddsa::sign(&priv_key_array, &sig_data)?,
+        _ => ecdsa::sign(&priv_key_array, &sig_data)?,
+    };
+
+    let credential_desc = PublicKeyCredentialDescriptor {
+        id: credential.id.clone(),
+        r#type: "public-key".to_string(),
+        transports: None,
+    };
+
+    let mut builder = MapBuilder::new()
+        .insert(resp_keys::CREDENTIAL, credential_desc)?
+        .insert_bytes(resp_keys::AUTH_DATA, &auth_data)?
+        .insert_bytes(resp_keys::SIGNATURE, &signature)?;
+
+    if credential.discoverable {
+        let user = crate::types::User {
+            id: credential.user_id.clone(),
+            name: if context.uv {
+                credential.user_name.clone()
+            } else {
+                None
+            },
+            display_name: if context.uv {
+                credential.user_display_name.clone()
+            } else {
+                None
+            },
+        };
+        builder = builder.insert(resp_keys::USER, user)?;
+    }
+
+    if remaining > 0 {
+        builder = builder.insert(resp_keys::NUMBER_OF_CREDENTIALS, remaining)?;
+    }
+
+    builder.build()
+}
+
+fn build_authenticator_data(rp_id: &str, up: bool, uv: bool, sign_count: u32) -> Vec<u8> {
+    let mut auth_data = Vec::new();
+
+    let mut hasher = Sha256::new();
+    hasher.update(rp_id.as_bytes());
+    auth_data.extend_from_slice(&hasher.finalize());
+
+    let mut flags = 0u8;
+    if up {
+        flags |= auth_data_flags::UP;
+    }
+    if uv {
+        flags |= auth_data_flags::UV;
+    }
+    auth_data.push(flags);
+
+    auth_data.extend_from_slice(&sign_count.to_be_bytes());
+    auth_data
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Store pending assertion state when userless getAssertion matches multiple discoverable credentials.
- Implement authenticatorGetNextAssertion to return remaining resident credential assertions.
- Clear stale assertion state on new getAssertion, timeout, completion, and reset.

## Verification
- cargo test -p soft-fido2-ctap get_next_assertion -- --nocapture
- cargo test -p passless-rs --test e2e_webauthn test_local_userless_multiple_discoverable_credentials -- --ignored --exact --test-threads=1 --nocapture
- Verified GitHub userless passkey login with two stored github.com credentials via passless.