### PR TITLE
release: Version 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.15.0](https://github.com/pando85/soft-fido2/tree/v0.15.0) - 2026-07-22
+
+### Added
+
+- Expose credential key provider in high-level authenticator (#126) ([1d8e244](https://github.com/pando85/soft-fido2/commit/1d8e2445cda291fd21732b680486a7b77301b0db))
+
 ## [v0.14.0](https://github.com/pando85/soft-fido2/tree/v0.14.0) - 2026-07-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Pando85 <pando855@gmail.com>"]
 rust-version = "1.91"
 edition = "2024"
@@ -13,9 +13,9 @@ repository = "https://github.com/pando85/soft-fido2"
 readme = "README.md"
 
 [workspace.dependencies]
-soft-fido2-crypto = { path = "soft-fido2-crypto", default-features = false, version = "0.14.0" }
-soft-fido2-ctap = { path = "soft-fido2-ctap", default-features = false, version = "0.14.0" }
-soft-fido2-transport = { path = "soft-fido2-transport", version = "0.14.0" }
+soft-fido2-crypto = { path = "soft-fido2-crypto", default-features = false, version = "0.15.0" }
+soft-fido2-ctap = { path = "soft-fido2-ctap", default-features = false, version = "0.15.0" }
+soft-fido2-transport = { path = "soft-fido2-transport", version = "0.15.0" }
 
 # Cryptography (well-audited crates)
 p256 = { version = "0.14", features = ["ecdsa", "ecdh", "getrandom"] }


### PR DESCRIPTION
Release v0.15.0 — exposes the credential key provider in the high-level Authenticator (#126). Needed by pando85/passless#314 (portable TPM backend).