### PR TITLE
security: reject ambiguous CTAP CBOR encodings

### DIFF
--- a/soft-fido2-ctap/src/cbor_validate.rs
+++ b/soft-fido2-ctap/src/cbor_validate.rs
@@ -1,0 +1,201 @@
+//! Validation for the restricted CBOR profile accepted by CTAP commands.
+//!
+//! The generic Serde decoder remains responsible for typed deserialization, but
+//! this module rejects ambiguous or resource-hostile encodings before any command
+//! handler performs authorization or cryptographic verification.
+
+use crate::status::{Result, StatusCode};
+use alloc::vec::Vec;
+
+/// CTAP permits at most four nested container levels.
+const MAX_NESTING_DEPTH: usize = 4;
+
+/// Validate exactly one deterministic CBOR item.
+pub(crate) fn validate_ctap_cbor(data: &[u8]) -> Result<()> {
+    if data.is_empty() {
+        return Err(StatusCode::InvalidCbor);
+    }
+
+    let mut offset = 0;
+    parse_item(data, &mut offset, 0)?;
+
+    if offset != data.len() {
+        return Err(StatusCode::InvalidCbor);
+    }
+
+    Ok(())
+}
+
+fn parse_item(data: &[u8], offset: &mut usize, container_depth: usize) -> Result<()> {
+    let initial = *data.get(*offset).ok_or(StatusCode::InvalidCbor)?;
+    *offset += 1;
+
+    let major = initial >> 5;
+    let additional = initial & 0x1f;
+
+    match major {
+        // Unsigned and negative integers.
+        0 | 1 => {
+            read_argument(data, offset, additional)?;
+        }
+        // Byte and text strings. Indefinite strings are rejected by
+        // read_argument().
+        2 | 3 => {
+            let length = read_length(data, offset, additional)?;
+            let end = offset
+                .checked_add(length)
+                .filter(|end| *end <= data.len())
+                .ok_or(StatusCode::InvalidCbor)?;
+
+            if major == 3 {
+                core::str::from_utf8(&data[*offset..end])
+                    .map_err(|_| StatusCode::InvalidCbor)?;
+            }
+            *offset = end;
+        }
+        // Arrays.
+        4 => {
+            if container_depth >= MAX_NESTING_DEPTH {
+                return Err(StatusCode::InvalidCbor);
+            }
+            let count = read_length(data, offset, additional)?;
+            for _ in 0..count {
+                parse_item(data, offset, container_depth + 1)?;
+            }
+        }
+        // Maps. Canonical encodings make the raw key bytes a stable identity,
+        // allowing duplicate keys to be rejected without allocating decoded keys.
+        5 => {
+            if container_depth >= MAX_NESTING_DEPTH {
+                return Err(StatusCode::InvalidCbor);
+            }
+            let count = read_length(data, offset, additional)?;
+            let mut keys: Vec<(usize, usize)> = Vec::with_capacity(count.min(32));
+
+            for _ in 0..count {
+                let key_start = *offset;
+                parse_item(data, offset, container_depth + 1)?;
+                let key_end = *offset;
+
+                if keys
+                    .iter()
+                    .any(|&(start, end)| data[start..end] == data[key_start..key_end])
+                {
+                    return Err(StatusCode::InvalidCbor);
+                }
+                keys.push((key_start, key_end));
+
+                parse_item(data, offset, container_depth + 1)?;
+            }
+        }
+        // CTAP CBOR does not use semantic tags.
+        6 => return Err(StatusCode::InvalidCbor),
+        // Only false, true, and null are needed by CTAP command structures.
+        // Floats, undefined, break, and extended simple values are rejected.
+        7 => match additional {
+            20..=22 => {}
+            _ => return Err(StatusCode::InvalidCbor),
+        },
+        _ => return Err(StatusCode::InvalidCbor),
+    }
+
+    Ok(())
+}
+
+fn read_length(data: &[u8], offset: &mut usize, additional: u8) -> Result<usize> {
+    let value = read_argument(data, offset, additional)?;
+    usize::try_from(value).map_err(|_| StatusCode::InvalidCbor)
+}
+
+/// Read a CBOR integer/length argument while enforcing its shortest encoding.
+fn read_argument(data: &[u8], offset: &mut usize, additional: u8) -> Result<u64> {
+    match additional {
+        value @ 0..=23 => Ok(value as u64),
+        24 => {
+            let value = read_exact::<1>(data, offset)?[0] as u64;
+            if value < 24 {
+                return Err(StatusCode::InvalidCbor);
+            }
+            Ok(value)
+        }
+        25 => {
+            let value = u16::from_be_bytes(read_exact::<2>(data, offset)?) as u64;
+            if value <= u8::MAX as u64 {
+                return Err(StatusCode::InvalidCbor);
+            }
+            Ok(value)
+        }
+        26 => {
+            let value = u32::from_be_bytes(read_exact::<4>(data, offset)?) as u64;
+            if value <= u16::MAX as u64 {
+                return Err(StatusCode::InvalidCbor);
+            }
+            Ok(value)
+        }
+        27 => {
+            let value = u64::from_be_bytes(read_exact::<8>(data, offset)?);
+            if value <= u32::MAX as u64 {
+                return Err(StatusCode::InvalidCbor);
+            }
+            Ok(value)
+        }
+        // 28-30 are reserved and 31 denotes an indefinite-length item.
+        _ => Err(StatusCode::InvalidCbor),
+    }
+}
+
+fn read_exact<const N: usize>(data: &[u8], offset: &mut usize) -> Result<[u8; N]> {
+    let end = offset
+        .checked_add(N)
+        .filter(|end| *end <= data.len())
+        .ok_or(StatusCode::InvalidCbor)?;
+    let bytes: [u8; N] = data[*offset..end]
+        .try_into()
+        .map_err(|_| StatusCode::InvalidCbor)?;
+    *offset = end;
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_canonical_ctap_map() {
+        assert_eq!(validate_ctap_cbor(&[0xa1, 0x01, 0x02]), Ok(()));
+    }
+
+    #[test]
+    fn rejects_duplicate_map_keys() {
+        assert_eq!(
+            validate_ctap_cbor(&[0xa2, 0x01, 0x02, 0x01, 0x03]),
+            Err(StatusCode::InvalidCbor)
+        );
+    }
+
+    #[test]
+    fn rejects_non_minimal_integer_encoding() {
+        assert_eq!(
+            validate_ctap_cbor(&[0xa1, 0x18, 0x01, 0x02]),
+            Err(StatusCode::InvalidCbor)
+        );
+    }
+
+    #[test]
+    fn rejects_tags_indefinite_items_and_floats() {
+        assert!(validate_ctap_cbor(&[0xa1, 0x01, 0xc0, 0x02]).is_err());
+        assert!(validate_ctap_cbor(&[0xbf, 0xff]).is_err());
+        assert!(validate_ctap_cbor(&[0xfa, 0x00, 0x00, 0x00, 0x00]).is_err());
+    }
+
+    #[test]
+    fn rejects_trailing_data() {
+        assert!(validate_ctap_cbor(&[0xa0, 0xa0]).is_err());
+    }
+
+    #[test]
+    fn rejects_excessive_nesting() {
+        assert!(validate_ctap_cbor(&[0x81, 0x81, 0x81, 0x81, 0x81, 0x00]).is_err());
+        assert!(validate_ctap_cbor(&[0x81, 0x81, 0x81, 0x81, 0x00]).is_ok());
+    }
+}

--- a/soft-fido2-ctap/src/cbor_validate.rs
+++ b/soft-fido2-ctap/src/cbor_validate.rs
@@ -48,8 +48,7 @@ fn parse_item(data: &[u8], offset: &mut usize, container_depth: usize) -> Result
                 .ok_or(StatusCode::InvalidCbor)?;
 
             if major == 3 {
-                core::str::from_utf8(&data[*offset..end])
-                    .map_err(|_| StatusCode::InvalidCbor)?;
+                core::str::from_utf8(&data[*offset..end]).map_err(|_| StatusCode::InvalidCbor)?;
             }
             *offset = end;
         }

--- a/soft-fido2-ctap/src/dispatcher.rs
+++ b/soft-fido2-ctap/src/dispatcher.rs
@@ -173,17 +173,11 @@ mod tests {
 
         // makeCredential plus a map containing duplicate key 1.
         let command = vec![0x01, 0xa2, 0x01, 0x01, 0x01, 0x02];
-        assert_eq!(
-            dispatcher.dispatch(&command),
-            Err(StatusCode::InvalidCbor)
-        );
+        assert_eq!(dispatcher.dispatch(&command), Err(StatusCode::InvalidCbor));
 
         // One valid map followed by an ignored second CBOR item.
         let command = vec![0x01, 0xa0, 0xa0];
-        assert_eq!(
-            dispatcher.dispatch(&command),
-            Err(StatusCode::InvalidCbor)
-        );
+        assert_eq!(dispatcher.dispatch(&command), Err(StatusCode::InvalidCbor));
     }
 
     #[test]

--- a/soft-fido2-ctap/src/dispatcher.rs
+++ b/soft-fido2-ctap/src/dispatcher.rs
@@ -6,6 +6,7 @@
 use crate::{
     authenticator::Authenticator,
     callbacks::AuthenticatorCallbacks,
+    cbor_validate::validate_ctap_cbor,
     commands::CommandCode,
     key_provider::{CredentialKeyProvider, SoftwareCredentialKeyProvider},
     status::{Result, StatusCode},
@@ -53,6 +54,13 @@ impl<C: AuthenticatorCallbacks, K: CredentialKeyProvider> CommandDispatcher<C, K
         let command_data = &data[1..];
 
         let cmd = CommandCode::from_u8(command_code).ok_or(StatusCode::InvalidCommand)?;
+
+        // Validate the restricted CTAP CBOR profile before typed decoding,
+        // authorization, or cryptographic processing. Commands with no request
+        // parameters legitimately have an empty command_data slice.
+        if !command_data.is_empty() {
+            validate_ctap_cbor(command_data)?;
+        }
 
         match cmd {
             CommandCode::MakeCredential => {
@@ -143,11 +151,7 @@ mod tests {
         let authenticator = Authenticator::new(config, MockCallbacks);
         let mut dispatcher = CommandDispatcher::new(authenticator);
 
-        // Invalid command code
-        let command = vec![0xFF];
-
-        let result = dispatcher.dispatch(&command);
-        assert!(result.is_err());
+        let result = dispatcher.dispatch(&[0xff]);
         assert_eq!(result.unwrap_err(), StatusCode::InvalidCommand);
     }
 
@@ -158,8 +162,28 @@ mod tests {
         let mut dispatcher = CommandDispatcher::new(authenticator);
 
         let result = dispatcher.dispatch(&[]);
-        assert!(result.is_err());
         assert_eq!(result.unwrap_err(), StatusCode::InvalidParameter);
+    }
+
+    #[test]
+    fn rejects_ambiguous_cbor_before_command_processing() {
+        let config = AuthenticatorConfig::new();
+        let authenticator = Authenticator::new(config, MockCallbacks);
+        let mut dispatcher = CommandDispatcher::new(authenticator);
+
+        // makeCredential plus a map containing duplicate key 1.
+        let command = vec![0x01, 0xa2, 0x01, 0x01, 0x01, 0x02];
+        assert_eq!(
+            dispatcher.dispatch(&command),
+            Err(StatusCode::InvalidCbor)
+        );
+
+        // One valid map followed by an ignored second CBOR item.
+        let command = vec![0x01, 0xa0, 0xa0];
+        assert_eq!(
+            dispatcher.dispatch(&command),
+            Err(StatusCode::InvalidCbor)
+        );
     }
 
     #[test]
@@ -174,9 +198,7 @@ mod tests {
         let command = vec![0x07];
 
         let response = dispatcher.dispatch(&command).unwrap();
-        assert!(response.is_empty()); // Reset returns empty response
-
-        // PIN should be cleared after reset
+        assert!(response.is_empty());
         assert!(!dispatcher.authenticator().is_pin_set());
     }
 }

--- a/soft-fido2-ctap/src/lib.rs
+++ b/soft-fido2-ctap/src/lib.rs
@@ -14,6 +14,7 @@ pub mod authenticator;
 pub mod bridge;
 pub mod callbacks;
 pub mod cbor;
+mod cbor_validate;
 pub mod commands;
 pub mod dispatcher;
 pub mod extensions;


### PR DESCRIPTION
## Summary

Adds a bounded validation pass for the restricted CBOR profile accepted by CTAP before Serde deserialization or authorization.

## Rejected inputs

- Duplicate map keys at any nesting level.
- Non-minimal integer and length encodings.
- Semantic tags, floats, undefined values, and extended simple values.
- Indefinite-length items.
- More than four nested container levels.
- Invalid UTF-8 text and truncated items.
- Multiple/trailing top-level CBOR items.

## Design

The validator is a small `no_std`-compatible byte parser. Typed command decoding remains unchanged and runs only after the raw request has a single deterministic interpretation.

## Passless compatibility

Passless and browsers produce ordinary canonical CTAP maps, so valid ceremonies should remain unchanged. The change primarily protects the virtual UHID authenticator from malicious local CTAP clients and parser-differential inputs.

Closes #140