### PR TITLE
fix: model dynamic built-in UV state

### DIFF
--- a/soft-fido2-ctap/src/authenticator.rs
+++ b/soft-fido2-ctap/src/authenticator.rs
@@ -556,6 +556,17 @@ impl<C: AuthenticatorCallbacks, K: CredentialKeyProvider> Authenticator<C, K> {
         self.pin_state.is_locked(now)
     }
 
+    /// Update whether built-in user verification is currently configured.
+    ///
+    /// This updates the `uv` value advertised by `authenticatorGetInfo` and
+    /// the built-in UV routing used by CTAP commands. If built-in UV is
+    /// unsupported (`uv` is absent), this method has no effect.
+    pub fn set_built_in_uv_configured(&mut self, configured: bool) {
+        if self.config.options.uv.is_some() {
+            self.config.options.uv = Some(configured);
+        }
+    }
+
     /// Check if built-in user verification is enabled
     ///
     /// Built-in UV refers to biometric authentication methods (fingerprint,
@@ -2147,6 +2158,33 @@ mod tests {
 
         // PIN meets new minimum
         assert!(auth.set_pin("12345678").is_ok());
+    }
+
+    #[test]
+    fn test_set_built_in_uv_configured_preserves_support_state() {
+        let config = AuthenticatorConfig::new().with_options(AuthenticatorOptions {
+            uv: Some(true),
+            ..AuthenticatorOptions::new()
+        });
+        let mut auth = Authenticator::new(config, MockCallbacks);
+
+        auth.set_built_in_uv_configured(false);
+        assert_eq!(auth.config().options.uv, Some(false));
+        assert!(!auth.has_built_in_uv_enabled());
+
+        auth.set_built_in_uv_configured(true);
+        assert_eq!(auth.config().options.uv, Some(true));
+        assert!(auth.has_built_in_uv_enabled());
+
+        let config = AuthenticatorConfig::new().with_options(AuthenticatorOptions {
+            uv: None,
+            ..AuthenticatorOptions::new()
+        });
+        let mut unsupported = Authenticator::new(config, MockCallbacks);
+
+        unsupported.set_built_in_uv_configured(true);
+        assert_eq!(unsupported.config().options.uv, None);
+        assert!(!unsupported.has_built_in_uv_enabled());
     }
 
     #[test]

--- a/soft-fido2-ctap/src/authenticator.rs
+++ b/soft-fido2-ctap/src/authenticator.rs
@@ -334,7 +334,7 @@ impl AuthenticatorOptions {
             bio_enroll: Some(false),
             ep: None,
             large_blobs: None,
-            pin_uv_auth_token: true,
+            pin_uv_auth_token: false,
             set_min_pin_length: false,
             make_cred_uv_not_rqd: false,
         }
@@ -618,7 +618,7 @@ impl<C: AuthenticatorCallbacks, K: CredentialKeyProvider> Authenticator<C, K> {
     /// invalidates active PIN/UV tokens and pending assertion state so policy
     /// changes take effect immediately.
     pub fn set_built_in_uv_state(&mut self, state: BuiltInUvState) -> Result<(), StatusCode> {
-        use BuiltInUvState::{Configured, Unsupported};
+        use BuiltInUvState::Unsupported;
 
         let current = self.built_in_uv_state;
         if current == state {
@@ -628,9 +628,6 @@ impl<C: AuthenticatorCallbacks, K: CredentialKeyProvider> Authenticator<C, K> {
         match (current, state) {
             (Unsupported, _) | (_, Unsupported) => {
                 return Err(StatusCode::UnsupportedOption);
-            }
-            (_, Configured) if !self.config.options.pin_uv_auth_token => {
-                return Err(StatusCode::InvalidOption);
             }
             _ => {}
         }
@@ -2271,25 +2268,6 @@ mod tests {
             Err(StatusCode::UnsupportedOption)
         );
         assert_eq!(unsupported.config().options.uv, None);
-    }
-
-    #[test]
-    fn test_configuring_uv_requires_pin_uv_auth_token_support() {
-        let config = AuthenticatorConfig::new().with_options(AuthenticatorOptions {
-            uv: Some(false),
-            pin_uv_auth_token: false,
-            ..AuthenticatorOptions::new()
-        });
-        let mut auth = Authenticator::new(config, MockCallbacks);
-
-        assert_eq!(
-            auth.set_built_in_uv_state(BuiltInUvState::Configured),
-            Err(StatusCode::InvalidOption)
-        );
-        assert_eq!(
-            auth.built_in_uv_state(),
-            BuiltInUvState::SupportedNotConfigured
-        );
     }
 
     #[test]

--- a/soft-fido2-ctap/src/authenticator.rs
+++ b/soft-fido2-ctap/src/authenticator.rs
@@ -334,10 +334,54 @@ impl AuthenticatorOptions {
             bio_enroll: Some(false),
             ep: None,
             large_blobs: None,
-            pin_uv_auth_token: false,
+            pin_uv_auth_token: true,
             set_min_pin_length: false,
             make_cred_uv_not_rqd: false,
         }
+    }
+}
+
+/// Runtime state of the authenticator's built-in user-verification method.
+///
+/// This mirrors the CTAP `authenticatorGetInfo.options.uv` tri-state while
+/// keeping runtime provisioning separate from immutable capability support.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuiltInUvState {
+    /// Built-in UV is not implemented by this authenticator.
+    Unsupported,
+    /// Built-in UV is supported but is not currently configured or available.
+    SupportedNotConfigured,
+    /// Built-in UV is supported and currently configured and available.
+    Configured,
+}
+
+impl BuiltInUvState {
+    /// Build the runtime state from the CTAP `uv` tri-state.
+    pub const fn from_get_info_value(value: Option<bool>) -> Self {
+        match value {
+            None => Self::Unsupported,
+            Some(false) => Self::SupportedNotConfigured,
+            Some(true) => Self::Configured,
+        }
+    }
+
+    /// Return the value that must be advertised in `authenticatorGetInfo`.
+    pub const fn get_info_value(self) -> Option<bool> {
+        match self {
+            Self::Unsupported => None,
+            Self::SupportedNotConfigured => Some(false),
+            Self::Configured => Some(true),
+        }
+    }
+
+    /// Whether this authenticator implements a built-in UV method.
+    pub const fn is_supported(self) -> bool {
+        !matches!(self, Self::Unsupported)
+    }
+
+    /// Whether built-in UV may currently be used by CTAP commands.
+    pub const fn is_configured(self) -> bool {
+        matches!(self, Self::Configured)
     }
 }
 
@@ -372,8 +416,11 @@ pub struct Authenticator<
     C: AuthenticatorCallbacks,
     K: CredentialKeyProvider = SoftwareCredentialKeyProvider,
 > {
-    /// Authenticator configuration
+    /// Authenticator configuration and immutable capabilities.
     config: AuthenticatorConfig,
+
+    /// Runtime provisioning/availability of built-in user verification.
+    built_in_uv_state: BuiltInUvState,
 
     /// Callbacks for user interaction and storage
     callbacks: Arc<C>,
@@ -460,12 +507,14 @@ impl<C: AuthenticatorCallbacks, K: CredentialKeyProvider> Authenticator<C, K> {
                 key
             }));
 
+        let built_in_uv_state = BuiltInUvState::from_get_info_value(config.options.uv);
         let max_pin_retries = config.max_pin_retries;
         let mut pin_state = PinState::new();
         pin_state.uv_retries = max_pin_retries;
 
         Self {
             config,
+            built_in_uv_state,
             callbacks: Arc::new(callbacks),
             key_provider,
             pin_state,
@@ -556,29 +605,57 @@ impl<C: AuthenticatorCallbacks, K: CredentialKeyProvider> Authenticator<C, K> {
         self.pin_state.is_locked(now)
     }
 
-    /// Update whether built-in user verification is currently configured.
-    ///
-    /// This updates the `uv` value advertised by `authenticatorGetInfo` and
-    /// the built-in UV routing used by CTAP commands. If built-in UV is
-    /// unsupported (`uv` is absent), this method has no effect.
-    pub fn set_built_in_uv_configured(&mut self, configured: bool) {
-        if self.config.options.uv.is_some() {
-            self.config.options.uv = Some(configured);
-        }
+    /// Return the current built-in UV runtime state.
+    pub fn built_in_uv_state(&self) -> BuiltInUvState {
+        self.built_in_uv_state
     }
 
-    /// Check if built-in user verification is enabled
+    /// Atomically transition the built-in UV runtime state.
     ///
-    /// Built-in UV refers to biometric authentication methods (fingerprint,
-    /// face recognition, iris scan, etc.) that are built into the authenticator.
+    /// Capability support is immutable after construction: an unsupported
+    /// authenticator cannot become supported at runtime, and a supported
+    /// authenticator cannot remove that capability. Any real state transition
+    /// invalidates active PIN/UV tokens and pending assertion state so policy
+    /// changes take effect immediately.
+    pub fn set_built_in_uv_state(&mut self, state: BuiltInUvState) -> Result<(), StatusCode> {
+        use BuiltInUvState::{Configured, Unsupported};
+
+        let current = self.built_in_uv_state;
+        if current == state {
+            return Ok(());
+        }
+
+        match (current, state) {
+            (Unsupported, _) | (_, Unsupported) => {
+                return Err(StatusCode::UnsupportedOption);
+            }
+            (_, Configured) if !self.config.options.pin_uv_auth_token => {
+                return Err(StatusCode::InvalidOption);
+            }
+            _ => {}
+        }
+
+        self.built_in_uv_state = state;
+        self.pin_tokens.clear_token();
+        self.assertion_state = None;
+        Ok(())
+    }
+
+    /// Convenience transition between configured and supported-not-configured.
+    pub fn set_built_in_uv_configured(&mut self, configured: bool) -> Result<(), StatusCode> {
+        let state = if configured {
+            BuiltInUvState::Configured
+        } else {
+            BuiltInUvState::SupportedNotConfigured
+        };
+        self.set_built_in_uv_state(state)
+    }
+
+    /// Check if built-in user verification is enabled.
     ///
-    /// For this virtual authenticator implementation, we consider built-in UV
-    /// as enabled if the `uv` config option is set to true. In a hardware
-    /// authenticator, this would check if biometric templates are enrolled.
-    ///
-    /// Note: Client PIN is NOT a built-in UV method per FIDO2 spec.
+    /// Note: Client PIN is not a built-in UV method.
     pub fn has_built_in_uv_enabled(&self) -> bool {
-        self.config.options.uv == Some(true)
+        self.built_in_uv_state.is_configured()
     }
 
     /// Check if authenticator is protected by any form of user verification
@@ -2161,19 +2238,25 @@ mod tests {
     }
 
     #[test]
-    fn test_set_built_in_uv_configured_preserves_support_state() {
+    fn test_built_in_uv_state_machine_preserves_capability() {
         let config = AuthenticatorConfig::new().with_options(AuthenticatorOptions {
             uv: Some(true),
             ..AuthenticatorOptions::new()
         });
         let mut auth = Authenticator::new(config, MockCallbacks);
 
-        auth.set_built_in_uv_configured(false);
-        assert_eq!(auth.config().options.uv, Some(false));
+        assert_eq!(auth.built_in_uv_state(), BuiltInUvState::Configured);
+        auth.set_built_in_uv_state(BuiltInUvState::SupportedNotConfigured)
+            .unwrap();
+        assert_eq!(
+            auth.built_in_uv_state(),
+            BuiltInUvState::SupportedNotConfigured
+        );
+        assert_eq!(auth.config().options.uv, Some(true));
         assert!(!auth.has_built_in_uv_enabled());
 
-        auth.set_built_in_uv_configured(true);
-        assert_eq!(auth.config().options.uv, Some(true));
+        auth.set_built_in_uv_configured(true).unwrap();
+        assert_eq!(auth.built_in_uv_state(), BuiltInUvState::Configured);
         assert!(auth.has_built_in_uv_enabled());
 
         let config = AuthenticatorConfig::new().with_options(AuthenticatorOptions {
@@ -2182,9 +2265,31 @@ mod tests {
         });
         let mut unsupported = Authenticator::new(config, MockCallbacks);
 
-        unsupported.set_built_in_uv_configured(true);
+        assert_eq!(unsupported.built_in_uv_state(), BuiltInUvState::Unsupported);
+        assert_eq!(
+            unsupported.set_built_in_uv_configured(true),
+            Err(StatusCode::UnsupportedOption)
+        );
         assert_eq!(unsupported.config().options.uv, None);
-        assert!(!unsupported.has_built_in_uv_enabled());
+    }
+
+    #[test]
+    fn test_configuring_uv_requires_pin_uv_auth_token_support() {
+        let config = AuthenticatorConfig::new().with_options(AuthenticatorOptions {
+            uv: Some(false),
+            pin_uv_auth_token: false,
+            ..AuthenticatorOptions::new()
+        });
+        let mut auth = Authenticator::new(config, MockCallbacks);
+
+        assert_eq!(
+            auth.set_built_in_uv_state(BuiltInUvState::Configured),
+            Err(StatusCode::InvalidOption)
+        );
+        assert_eq!(
+            auth.built_in_uv_state(),
+            BuiltInUvState::SupportedNotConfigured
+        );
     }
 
     #[test]

--- a/soft-fido2-ctap/src/commands/client_pin.rs
+++ b/soft-fido2-ctap/src/commands/client_pin.rs
@@ -579,6 +579,7 @@ fn handle_get_pin_uv_auth_token_using_uv_with_permissions<
 
     // Check permission authorization based on authenticator options
     // Permission bits: mc=0x01, ga=0x02, cm=0x04, be=0x08, lbw=0x10, acfg=0x20
+    let built_in_uv_state = auth.built_in_uv_state();
     let config = auth.config();
 
     // cm (0x04) requires credMgmt to be true
@@ -610,7 +611,7 @@ fn handle_get_pin_uv_auth_token_using_uv_with_permissions<
 
     // Check if built-in UV is configured
     // For our implementation, UV is always available via callbacks
-    if config.options.uv.is_none() || !config.options.uv.unwrap() {
+    if !built_in_uv_state.is_configured() {
         return Err(StatusCode::NotAllowed);
     }
 
@@ -758,13 +759,39 @@ mod tests {
     use super::*;
 
     use crate::{
-        authenticator::{Authenticator, AuthenticatorConfig},
+        authenticator::{Authenticator, AuthenticatorConfig, AuthenticatorOptions},
         test_utils::MockCallbacks,
     };
 
     fn create_test_authenticator() -> Authenticator<MockCallbacks> {
         let config = AuthenticatorConfig::new();
         Authenticator::new(config, MockCallbacks)
+    }
+
+    #[test]
+    fn test_uv_token_request_rejects_supported_not_configured_without_retry() {
+        let config = AuthenticatorConfig::new().with_options(AuthenticatorOptions {
+            uv: Some(false),
+            pin_uv_auth_token: true,
+            ..AuthenticatorOptions::new()
+        });
+        let mut auth = Authenticator::new(config, MockCallbacks);
+        let retries = auth.uv_retries();
+        let key_agreement = MapBuilder::new().build_value().unwrap();
+        let request = MapBuilder::new()
+            .insert(req_keys::SUBCOMMAND, 0x06u8)
+            .unwrap()
+            .insert(req_keys::PIN_UV_AUTH_PROTOCOL, 2u8)
+            .unwrap()
+            .insert(req_keys::KEY_AGREEMENT, key_agreement)
+            .unwrap()
+            .insert(req_keys::PERMISSIONS, 0x01u8)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert_eq!(handle(&mut auth, &request), Err(StatusCode::NotAllowed));
+        assert_eq!(auth.uv_retries(), retries);
     }
 
     #[test]

--- a/soft-fido2-ctap/src/commands/get_assertion.rs
+++ b/soft-fido2-ctap/src/commands/get_assertion.rs
@@ -274,17 +274,9 @@ pub fn handle<C: AuthenticatorCallbacks, K: CredentialKeyProvider>(
         options.uv = false;
     }
 
-    // Step 4.3: If "uv" option is present and true
-    if options.uv {
-        // Check if authenticator supports built-in user verification
-        if !auth.config().options.uv.unwrap_or(false) {
-            return Err(StatusCode::InvalidOption);
-        }
-        // Check if built-in user verification method is enabled
-        // Built-in UV refers to biometric methods (fingerprint, face recognition, etc.)
-        if !auth.has_built_in_uv_enabled() {
-            return Err(StatusCode::InvalidOption);
-        }
+    // Step 4.3: If "uv" is true, built-in UV must be configured now.
+    if options.uv && !auth.built_in_uv_state().is_configured() {
+        return Err(StatusCode::InvalidOption);
     }
 
     // Step 4.4: If "rk" option is present, return error
@@ -789,6 +781,41 @@ fn build_authenticator_data(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::{
+        authenticator::{Authenticator, AuthenticatorConfig, AuthenticatorOptions, BuiltInUvState},
+        cbor::Value,
+        test_utils::MockCallbacks,
+    };
+
+    #[test]
+    fn test_get_assertion_uses_runtime_built_in_uv_state() {
+        let config = AuthenticatorConfig::new().with_options(AuthenticatorOptions {
+            uv: Some(false),
+            pin_uv_auth_token: true,
+            ..AuthenticatorOptions::new()
+        });
+        let mut auth = Authenticator::new(config, MockCallbacks);
+        auth.set_built_in_uv_state(BuiltInUvState::Configured)
+            .unwrap();
+
+        let options = Value::Map(vec![(Value::Text("uv".into()), Value::Bool(true))]);
+        let request = MapBuilder::new()
+            .insert(req_keys::RP_ID, "example.com")
+            .unwrap()
+            .insert_bytes(req_keys::CLIENT_DATA_HASH, &[0x42; 32])
+            .unwrap()
+            .insert(req_keys::OPTIONS, options)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert_eq!(handle(&mut auth, &request), Err(StatusCode::NoCredentials));
+
+        auth.set_built_in_uv_state(BuiltInUvState::SupportedNotConfigured)
+            .unwrap();
+        assert_eq!(handle(&mut auth, &request), Err(StatusCode::InvalidOption));
+    }
 
     #[test]
     fn test_build_authenticator_data() {

--- a/soft-fido2-ctap/src/commands/get_info.rs
+++ b/soft-fido2-ctap/src/commands/get_info.rs
@@ -123,7 +123,7 @@ pub fn handle<C: AuthenticatorCallbacks, K: crate::key_provider::CredentialKeyPr
         ep: config.options.ep,
         rk: Some(config.options.rk),
         up: Some(config.options.up),
-        uv: config.options.uv,
+        uv: auth.built_in_uv_state().get_info_value(),
         plat: Some(config.options.plat),
         always_uv: Some(config.options.always_uv),
         cred_mgmt: Some(config.options.cred_mgmt),
@@ -199,10 +199,25 @@ mod tests {
     use super::*;
 
     use crate::{
-        authenticator::AuthenticatorConfig,
+        authenticator::{AuthenticatorConfig, AuthenticatorOptions, BuiltInUvState},
         cbor::{MapParser, Value},
         test_utils::MockCallbacks,
     };
+
+    fn option_bool(response: &[u8], name: &str) -> Option<bool> {
+        let parser = MapParser::from_bytes(response).unwrap();
+        let options: Value = parser.get(keys::OPTIONS).unwrap();
+        let Value::Map(options) = options else {
+            panic!("options must be a map");
+        };
+
+        options
+            .into_iter()
+            .find_map(|(key, value)| match (key, value) {
+                (Value::Text(key), Value::Bool(value)) if key == name => Some(value),
+                _ => None,
+            })
+    }
 
     #[test]
     fn test_get_info_basic() {
@@ -275,6 +290,29 @@ mod tests {
         let extensions: Vec<String> = parser.get(keys::EXTENSIONS).unwrap();
 
         assert_eq!(extensions, vec!["credProtect".to_string()]);
+    }
+
+    #[test]
+    fn test_get_info_derives_uv_from_runtime_state() {
+        let config = AuthenticatorConfig::new().with_options(AuthenticatorOptions {
+            uv: Some(true),
+            ..AuthenticatorOptions::new()
+        });
+        let mut auth = Authenticator::new(config, MockCallbacks);
+
+        assert_eq!(option_bool(&handle(&auth).unwrap(), "uv"), Some(true));
+
+        auth.set_built_in_uv_state(BuiltInUvState::SupportedNotConfigured)
+            .unwrap();
+        assert_eq!(option_bool(&handle(&auth).unwrap(), "uv"), Some(false));
+        assert_eq!(auth.config().options.uv, Some(true));
+
+        auth.set_built_in_uv_state(BuiltInUvState::Configured)
+            .unwrap();
+        assert_eq!(option_bool(&handle(&auth).unwrap(), "uv"), Some(true));
+
+        let unsupported = Authenticator::new(AuthenticatorConfig::new(), MockCallbacks);
+        assert_eq!(option_bool(&handle(&unsupported).unwrap(), "uv"), None);
     }
 
     #[test]

--- a/soft-fido2-ctap/src/commands/make_credential.rs
+++ b/soft-fido2-ctap/src/commands/make_credential.rs
@@ -216,7 +216,7 @@ pub fn handle<C: AuthenticatorCallbacks, K: CredentialKeyProvider>(
     // 5.3: If "uv" option is true, validate built-in UV support
     if options.uv {
         // Check if authenticator supports a built-in user verification method
-        if auth.config().options.uv != Some(true) {
+        if !auth.built_in_uv_state().is_configured() {
             return Err(StatusCode::InvalidOption);
         }
     }

--- a/soft-fido2-ctap/src/lib.rs
+++ b/soft-fido2-ctap/src/lib.rs
@@ -27,7 +27,7 @@ pub mod test_utils;
 pub mod types;
 
 // Re-export commonly used types
-pub use authenticator::{Authenticator, AuthenticatorConfig};
+pub use authenticator::{Authenticator, AuthenticatorConfig, BuiltInUvState};
 #[cfg(feature = "transport")]
 pub use bridge::TransportBridge;
 pub use callbacks::{

--- a/soft-fido2/src/authenticator.rs
+++ b/soft-fido2/src/authenticator.rs
@@ -6,6 +6,7 @@
 use crate::error::Error;
 use crate::error::Result;
 use crate::types::{Credential, CredentialBackupState, CredentialRef};
+pub use soft_fido2_ctap::authenticator::BuiltInUvState;
 use soft_fido2_ctap::authenticator::{
     Authenticator as CtapAuthenticator, AuthenticatorConfig as CtapConfig,
 };
@@ -898,11 +899,18 @@ impl<C: AuthenticatorCallbacks, K: CredentialKeyProvider + Send + 'static> Authe
         Ok(dispatcher.authenticator().uv_retries())
     }
 
-    /// Update whether built-in user verification is currently configured.
-    ///
-    /// The value is reflected in `authenticatorGetInfo` and built-in UV
-    /// routing. If built-in UV is unsupported, this method has no effect.
-    pub fn set_built_in_uv_configured(&mut self, configured: bool) -> Result<()> {
+    /// Return the current built-in UV runtime state.
+    pub fn built_in_uv_state(&self) -> Result<BuiltInUvState> {
+        #[cfg(feature = "std")]
+        let dispatcher = self.dispatcher.lock().map_err(|_| Error::Other)?;
+        #[cfg(not(feature = "std"))]
+        let dispatcher = self.dispatcher.lock();
+
+        Ok(dispatcher.authenticator().built_in_uv_state())
+    }
+
+    /// Atomically transition built-in UV provisioning/availability.
+    pub fn set_built_in_uv_state(&mut self, state: BuiltInUvState) -> Result<()> {
         #[cfg(feature = "std")]
         let mut dispatcher = self.dispatcher.lock().map_err(|_| Error::Other)?;
         #[cfg(not(feature = "std"))]
@@ -910,8 +918,18 @@ impl<C: AuthenticatorCallbacks, K: CredentialKeyProvider + Send + 'static> Authe
 
         dispatcher
             .authenticator_mut()
-            .set_built_in_uv_configured(configured);
-        Ok(())
+            .set_built_in_uv_state(state)
+            .map_err(Into::into)
+    }
+
+    /// Convenience transition between configured and supported-not-configured.
+    pub fn set_built_in_uv_configured(&mut self, configured: bool) -> Result<()> {
+        let state = if configured {
+            BuiltInUvState::Configured
+        } else {
+            BuiltInUvState::SupportedNotConfigured
+        };
+        self.set_built_in_uv_state(state)
     }
 
     /// Reset UV retry counter to maximum value
@@ -1133,7 +1151,7 @@ mod tests {
     }
 
     #[test]
-    fn test_set_built_in_uv_configured_is_exposed() {
+    fn test_built_in_uv_state_machine_is_exposed() {
         let options = crate::options::AuthenticatorOptions {
             uv: Some(true),
             ..Default::default()
@@ -1141,8 +1159,21 @@ mod tests {
         let config = AuthenticatorConfig::builder().options(options).build();
         let mut auth = Authenticator::with_config(TestCallbacks, config).unwrap();
 
-        auth.set_built_in_uv_configured(false).unwrap();
+        assert_eq!(
+            auth.built_in_uv_state().unwrap(),
+            BuiltInUvState::Configured
+        );
+        auth.set_built_in_uv_state(BuiltInUvState::SupportedNotConfigured)
+            .unwrap();
+        assert_eq!(
+            auth.built_in_uv_state().unwrap(),
+            BuiltInUvState::SupportedNotConfigured
+        );
         auth.set_built_in_uv_configured(true).unwrap();
+        assert_eq!(
+            auth.built_in_uv_state().unwrap(),
+            BuiltInUvState::Configured
+        );
     }
 
     #[test]

--- a/soft-fido2/src/authenticator.rs
+++ b/soft-fido2/src/authenticator.rs
@@ -898,6 +898,22 @@ impl<C: AuthenticatorCallbacks, K: CredentialKeyProvider + Send + 'static> Authe
         Ok(dispatcher.authenticator().uv_retries())
     }
 
+    /// Update whether built-in user verification is currently configured.
+    ///
+    /// The value is reflected in `authenticatorGetInfo` and built-in UV
+    /// routing. If built-in UV is unsupported, this method has no effect.
+    pub fn set_built_in_uv_configured(&mut self, configured: bool) -> Result<()> {
+        #[cfg(feature = "std")]
+        let mut dispatcher = self.dispatcher.lock().map_err(|_| Error::Other)?;
+        #[cfg(not(feature = "std"))]
+        let mut dispatcher = self.dispatcher.lock();
+
+        dispatcher
+            .authenticator_mut()
+            .set_built_in_uv_configured(configured);
+        Ok(())
+    }
+
     /// Reset UV retry counter to maximum value
     ///
     /// Delegates to the underlying CTAP authenticator's UV retry logic.
@@ -1114,6 +1130,19 @@ mod tests {
 
         assert_eq!(config.aaguid, [1u8; 16]);
         assert_eq!(config.max_credentials, 50);
+    }
+
+    #[test]
+    fn test_set_built_in_uv_configured_is_exposed() {
+        let options = crate::options::AuthenticatorOptions {
+            uv: Some(true),
+            ..Default::default()
+        };
+        let config = AuthenticatorConfig::builder().options(options).build();
+        let mut auth = Authenticator::with_config(TestCallbacks, config).unwrap();
+
+        auth.set_built_in_uv_configured(false).unwrap();
+        auth.set_built_in_uv_configured(true).unwrap();
     }
 
     #[test]

--- a/soft-fido2/src/lib.rs
+++ b/soft-fido2/src/lib.rs
@@ -68,7 +68,7 @@ pub mod uhid;
 // Re-export main types at root level for convenience
 pub use authenticator::{
     Authenticator, AuthenticatorCallbacks, AuthenticatorConfig, AuthenticatorConfigBuilder,
-    UpResult, UvResult,
+    BuiltInUvState, UpResult, UvResult,
 };
 pub use ctap::CtapCommand;
 pub use error::{Error, Result};


### PR DESCRIPTION
## Summary

Model built-in user verification as explicit runtime state instead of mutating the CTAP wire-format `uv` option directly.

This lets embedding authenticators keep `authenticatorGetInfo.options.uv` truthful when their effective verification policy changes at runtime, without misusing CTAP errors to steer platforms toward Client PIN.

Related: pando85/passless#393

## Problem

`AuthenticatorOptions.uv` previously acted as both an immutable capability declaration and mutable provisioning state. Applications such as Passless can change their effective UV policy after loading or modifying PIN state, but could not update the runtime state advertised through `authenticatorGetInfo` consistently across all CTAP command paths.

When an authenticator advertised `uv: true` while application policy refused built-in UV, platforms could select `getPinUvAuthTokenUsingUvWithPermissions` (`authenticatorClientPIN` subcommand `0x06`). A callback-level policy denial was then interpreted as a real UV rejection, returning `CTAP2_ERR_OPERATION_DENIED` and consuming a UV retry instead of selecting Client PIN directly.

## Design

Introduce a typed three-state model:

```rust
pub enum BuiltInUvState {
    Unsupported,
    SupportedNotConfigured,
    Configured,
}
```

The model separates immutable capability support from runtime provisioning/availability:

- `Unsupported` maps to an absent `uv` option and cannot transition to a supported state at runtime.
- `SupportedNotConfigured` maps to `uv: false`.
- `Configured` maps to `uv: true`.
- Built-in UV state remains independent of `pinUvAuthToken` support, preserving authenticators that perform direct built-in UV without issuing permissioned tokens.

A real state transition atomically invalidates the current PIN/UV token and pending `getNextAssertion` state so a policy change takes effect immediately.

## API

Expose the state model through both CTAP and high-level authenticators:

- `built_in_uv_state()`
- `set_built_in_uv_state(BuiltInUvState)`
- `set_built_in_uv_configured(bool)` as a convenience wrapper

Unsupported capability transitions return an error instead of silently changing authenticator capabilities.

## Protocol behavior

`authenticatorGetInfo.options.uv` is now derived from the runtime state rather than stored as independently mutable wire state.

The same runtime state is consumed by:

- `authenticatorClientPIN/getPinUvAuthTokenUsingUvWithPermissions`
- `authenticatorMakeCredential`
- `authenticatorGetAssertion`

When built-in UV is supported but not configured, subcommand `0x06` returns `CTAP2_ERR_NOT_ALLOWED` before invoking UV and without decrementing `uvRetries`.

## Tests

Regression coverage includes:

- all three `uv` wire states: absent, `false`, and `true`;
- preserving immutable unsupported capability;
- transitions in both directions for initially configured and initially unconfigured authenticators;
- `getInfo` deriving `uv` from runtime state;
- `getPinUvAuthTokenUsingUvWithPermissions` returning `NOT_ALLOWED` without consuming a UV retry;
- `getAssertion` routing through the runtime state in both configured and not-configured states;
- high-level API exposure.

## Validation

Validated on the repository runner with Rust 1.97.1:

- `cargo fmt --all`
- `cargo test --verbose`
- `cargo clippy --no-default-features --lib -- --deny warnings`

The repository's standard `Pre-commit` and `Rust` pull-request workflows also passed on the final tree.